### PR TITLE
Set default language to English and add date/time formatting utilities

### DIFF
--- a/src/com/utils/DateTimeFormatter.java
+++ b/src/com/utils/DateTimeFormatter.java
@@ -1,0 +1,284 @@
+package com.utils;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.GregorianCalendar;
+
+/**
+ * Utility class for formatting dates and times according to the current locale.
+ * Provides consistent date/time formatting throughout the application.
+ *
+ * @author Daniel Batres
+ * @version 1.0.0
+ * @since 2024
+ */
+public class DateTimeFormatter {
+
+    // Standard date format patterns for English locale
+    private static final String DATE_PATTERN = "MM/dd/yyyy";
+    private static final String DATE_TIME_PATTERN = "MM/dd/yyyy HH:mm";
+    private static final String TIME_PATTERN = "HH:mm";
+    private static final String FULL_DATE_PATTERN = "EEEE, MMMM dd, yyyy";
+    private static final String MONTH_YEAR_PATTERN = "MMMM yyyy";
+    private static final String SHORT_DATE_PATTERN = "MM/dd/yy";
+
+    /**
+     * Formats a date using the default date pattern (MM/dd/yyyy)
+     *
+     * @param date the date to format
+     * @return formatted date string
+     */
+    public static String formatDate(Date date) {
+        if (date == null) return "";
+        SimpleDateFormat formatter = new SimpleDateFormat(DATE_PATTERN, Locale.ENGLISH);
+        return formatter.format(date);
+    }
+
+    /**
+     * Formats a date and time using the default datetime pattern
+     *
+     * @param date the date to format
+     * @return formatted datetime string
+     */
+    public static String formatDateTime(Date date) {
+        if (date == null) return "";
+        SimpleDateFormat formatter = new SimpleDateFormat(DATE_TIME_PATTERN, Locale.ENGLISH);
+        return formatter.format(date);
+    }
+
+    /**
+     * Formats just the time portion of a date
+     *
+     * @param date the date to format
+     * @return formatted time string
+     */
+    public static String formatTime(Date date) {
+        if (date == null) return "";
+        SimpleDateFormat formatter = new SimpleDateFormat(TIME_PATTERN, Locale.ENGLISH);
+        return formatter.format(date);
+    }
+
+    /**
+     * Formats a date with full day and month names (e.g., "Monday, January 15, 2024")
+     *
+     * @param date the date to format
+     * @return formatted full date string
+     */
+    public static String formatFullDate(Date date) {
+        if (date == null) return "";
+        SimpleDateFormat formatter = new SimpleDateFormat(FULL_DATE_PATTERN, Locale.ENGLISH);
+        return formatter.format(date);
+    }
+
+    /**
+     * Formats a date showing only month and year (e.g., "January 2024")
+     *
+     * @param date the date to format
+     * @return formatted month-year string
+     */
+    public static String formatMonthYear(Date date) {
+        if (date == null) return "";
+        SimpleDateFormat formatter = new SimpleDateFormat(MONTH_YEAR_PATTERN, Locale.ENGLISH);
+        return formatter.format(date);
+    }
+
+    /**
+     * Formats a date using short format (MM/dd/yy)
+     *
+     * @param date the date to format
+     * @return formatted short date string
+     */
+    public static String formatShortDate(Date date) {
+        if (date == null) return "";
+        SimpleDateFormat formatter = new SimpleDateFormat(SHORT_DATE_PATTERN, Locale.ENGLISH);
+        return formatter.format(date);
+    }
+
+    /**
+     * Formats the current date and time
+     *
+     * @return formatted current datetime string
+     */
+    public static String formatCurrentDateTime() {
+        return formatDateTime(new Date());
+    }
+
+    /**
+     * Formats the current date
+     *
+     * @return formatted current date string
+     */
+    public static String formatCurrentDate() {
+        return formatDate(new Date());
+    }
+
+    /**
+     * Formats the current time
+     *
+     * @return formatted current time string
+     */
+    public static String formatCurrentTime() {
+        return formatTime(new Date());
+    }
+
+    /**
+     * Creates a date from day, month, year integers
+     *
+     * @param day day of month (1-31)
+     * @param month month (1-12)
+     * @param year full year (e.g., 2024)
+     * @return Date object or null if invalid
+     */
+    public static Date createDate(int day, int month, int year) {
+        try {
+            Calendar calendar = new GregorianCalendar(year, month - 1, day);
+            calendar.setLenient(false); // Strict date validation
+            return calendar.getTime();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Creates a date with time from integers
+     *
+     * @param day day of month (1-31)
+     * @param month month (1-12)
+     * @param year full year (e.g., 2024)
+     * @param hour hour (0-23)
+     * @param minute minute (0-59)
+     * @return Date object or null if invalid
+     */
+    public static Date createDateTime(int day, int month, int year, int hour, int minute) {
+        try {
+            Calendar calendar = new GregorianCalendar(year, month - 1, day, hour, minute);
+            calendar.setLenient(false); // Strict date validation
+            return calendar.getTime();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the localized name of a month
+     *
+     * @param month month number (1-12)
+     * @return localized month name
+     */
+    public static String getMonthName(int month) {
+        if (month < 1 || month > 12) return "";
+
+        String[] monthKeys = {
+            "month.january", "month.february", "month.march", "month.april",
+            "month.may", "month.june", "month.july", "month.august",
+            "month.september", "month.october", "month.november", "month.december"
+        };
+
+        return Messages.get(monthKeys[month - 1]);
+    }
+
+    /**
+     * Gets the localized short name of a month
+     *
+     * @param month month number (1-12)
+     * @return localized short month name
+     */
+    public static String getShortMonthName(int month) {
+        if (month < 1 || month > 12) return "";
+
+        String[] monthKeys = {
+            "month.short.jan", "month.short.feb", "month.short.mar", "month.short.apr",
+            "month.short.may", "month.short.jun", "month.short.jul", "month.short.aug",
+            "month.short.sep", "month.short.oct", "month.short.nov", "month.short.dec"
+        };
+
+        return Messages.get(monthKeys[month - 1]);
+    }
+
+    /**
+     * Gets the localized name of a day of the week
+     *
+     * @param dayOfWeek day of week (1=Sunday, 2=Monday, ..., 7=Saturday)
+     * @return localized day name
+     */
+    public static String getDayName(int dayOfWeek) {
+        if (dayOfWeek < 1 || dayOfWeek > 7) return "";
+
+        String[] dayKeys = {
+            "day.sunday", "day.monday", "day.tuesday", "day.wednesday",
+            "day.thursday", "day.friday", "day.saturday"
+        };
+
+        return Messages.get(dayKeys[dayOfWeek - 1]);
+    }
+
+    /**
+     * Validates if a date string matches the expected format
+     *
+     * @param dateString the date string to validate
+     * @param pattern the expected pattern
+     * @return true if valid, false otherwise
+     */
+    public static boolean isValidDate(String dateString, String pattern) {
+        if (dateString == null || dateString.trim().isEmpty()) return false;
+
+        try {
+            SimpleDateFormat formatter = new SimpleDateFormat(pattern, Locale.ENGLISH);
+            formatter.setLenient(false);
+            formatter.parse(dateString);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Validates if a date string matches the default date format
+     *
+     * @param dateString the date string to validate
+     * @return true if valid, false otherwise
+     */
+    public static boolean isValidDate(String dateString) {
+        return isValidDate(dateString, DATE_PATTERN);
+    }
+
+    /**
+     * Gets a relative time description (e.g., "Today", "Yesterday", "2 days ago")
+     *
+     * @param date the date to compare
+     * @return relative time description
+     */
+    public static String getRelativeTime(Date date) {
+        if (date == null) return "";
+
+        Calendar cal = Calendar.getInstance();
+        Calendar today = Calendar.getInstance();
+        cal.setTime(date);
+
+        // Check if same day
+        if (cal.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR)) {
+            return Messages.get("date.hoy");
+        }
+
+        // Check if yesterday
+        today.add(Calendar.DAY_OF_YEAR, -1);
+        if (cal.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR)) {
+            return Messages.get("date.ayer");
+        }
+
+        // Check if tomorrow
+        today.add(Calendar.DAY_OF_YEAR, 2);
+        if (cal.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR)) {
+            return Messages.get("date.manana");
+        }
+
+        // Otherwise return formatted date
+        return formatDate(date);
+    }
+}

--- a/src/com/utils/Messages.java
+++ b/src/com/utils/Messages.java
@@ -99,6 +99,77 @@ public class Messages {
     }
 
     /**
+     * Gets a localized message with proper plural form handling
+     *
+     * @param key the base message key
+     * @param count the count to determine singular/plural form
+     * @param params additional parameters to substitute in the message
+     * @return the localized message with proper plural form and parameters substituted
+     */
+    public static String getPlural(String key, int count, Object... params) {
+        String pluralKey = key;
+
+        // Determine plural form based on English rules
+        if (count == 1) {
+            pluralKey = key + ".singular";
+        } else {
+            pluralKey = key + ".plural";
+        }
+
+        // Try to get the plural-specific key first
+        String message;
+        if (hasKey(pluralKey)) {
+            message = get(pluralKey);
+        } else {
+            // Fallback to base key if plural-specific key doesn't exist
+            message = get(key);
+        }
+
+        // Create parameters array with count as first parameter
+        Object[] allParams = new Object[params.length + 1];
+        allParams[0] = count;
+        System.arraycopy(params, 0, allParams, 1, params.length);
+
+        // Substitute parameters
+        for (int i = 0; i < allParams.length; i++) {
+            message = message.replace("{" + i + "}", String.valueOf(allParams[i]));
+        }
+
+        return message;
+    }
+
+    /**
+     * Gets a localized message for counts with automatic singular/plural handling
+     *
+     * @param key the base message key (without .singular/.plural suffix)
+     * @param count the count to display and use for plural determination
+     * @return the localized message with count and proper plural form
+     */
+    public static String getCount(String key, int count) {
+        return getPlural(key, count);
+    }
+
+    /**
+     * Gets a formatted message for displaying counts of items
+     *
+     * @param itemKey the key for the item name
+     * @param count the count of items
+     * @return formatted message like "5 patients" or "1 patient"
+     */
+    public static String getItemCount(String itemKey, int count) {
+        String itemName = get(itemKey);
+        if (count == 1) {
+            return count + " " + itemName;
+        } else {
+            // Simple English pluralization - add 's' if not already plural
+            if (!itemName.endsWith("s")) {
+                itemName += "s";
+            }
+            return count + " " + itemName;
+        }
+    }
+
+    /**
      * Checks if a message key exists in the resource bundle
      *
      * @param key the message key to check

--- a/src/com/view/appointmentsView/Agendas.java
+++ b/src/com/view/appointmentsView/Agendas.java
@@ -169,40 +169,40 @@ public class Agendas extends Styles {
         
         switch (monthValue) {
             case JANUARY:
-                mesText = "Enero";
+                mesText = Messages.get("month.january");
                 break;
             case FEBRUARY:
-                mesText = "Febrero";
+                mesText = Messages.get("month.february");
                 break;
             case MARCH:
-                mesText = "Marzo";
+                mesText = Messages.get("month.march");
                 break;
             case APRIL:
-                mesText = "Abril";
+                mesText = Messages.get("month.april");
                 break;
             case MAY:
-                mesText = "Mayo";
+                mesText = Messages.get("month.may");
                 break;
             case JUNE:
-                mesText = "Junio";
+                mesText = Messages.get("month.june");
                 break;
             case JULY:
-                mesText = "Julio";
+                mesText = Messages.get("month.july");
                 break;
             case AUGUST:
-                mesText = "Agosto";
+                mesText = Messages.get("month.august");
                 break;
             case SEPTEMBER:
-                mesText = "Septiembre";
+                mesText = Messages.get("month.september");
                 break;
             case OCTOBER:
-                mesText = "Octubre";
+                mesText = Messages.get("month.october");
                 break;
             case NOVEMBER:
-                mesText = "Noviembre";
+                mesText = Messages.get("month.november");
                 break;
             case DECEMBER:
-                mesText = "Diciembre";
+                mesText = Messages.get("month.december");
                 break;
         }
         
@@ -214,40 +214,40 @@ public class Agendas extends Styles {
         int value = 0;
         
         switch (month) {
-            case "Enero":
+            case "January":
                 value = Month.JANUARY.getValue();
                 break;
-            case "Febrero":
+            case "February":
                 value = Month.FEBRUARY.getValue();
                 break;
-            case "Marzo":
+            case "March":
                 value = Month.MARCH.getValue();
                 break;
-            case "Abril":
+            case "April":
                 value = Month.APRIL.getValue();
                 break;
-            case "Mayo":
+            case "May":
                 value = Month.MAY.getValue();
                 break;
-            case "Junio":
+            case "June":
                 value = Month.JUNE.getValue();
                 break;
-            case "Julio":
+            case "July":
                 value = Month.JULY.getValue();
                 break;
-            case "Agosto":
+            case "August":
                 value = Month.AUGUST.getValue();
                 break;
-            case "Septiembre":
+            case "September":
                 value = Month.SEPTEMBER.getValue();
                 break;
-            case "Octubre":
+            case "October":
                 value = Month.OCTOBER.getValue();
                 break;
-            case "Noviembre":
+            case "November":
                 value = Month.NOVEMBER.getValue();
                 break;
-            case "Diciembre":
+            case "December":
                 value = Month.DECEMBER.getValue();
                 break;
         }
@@ -1099,7 +1099,7 @@ public class Agendas extends Styles {
         fecha.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         fecha.setForeground(new java.awt.Color(0, 0, 0));
         fecha.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
-        fecha.setText("Septiembre 2022");
+        fecha.setText(Messages.get("month.september") + " 2022");
 
         javax.swing.GroupLayout jPanel26Layout = new javax.swing.GroupLayout(jPanel26);
         jPanel26.setLayout(jPanel26Layout);

--- a/src/com/view/appointmentsView/AppointmentTarget.java
+++ b/src/com/view/appointmentsView/AppointmentTarget.java
@@ -34,7 +34,7 @@ public class AppointmentTarget extends Styles {
         tratamientoText.setText(consulta.getTratamientoDeConsulta());
         
         if (consulta.isConsultaRealizada()) {
-            facturaText.setText("View Invoice");
+            facturaText.setText(Messages.get("factura.ver"));
         }
     }
     
@@ -374,7 +374,7 @@ public class AppointmentTarget extends Styles {
         facturaText.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         facturaText.setForeground(new java.awt.Color(0, 0, 0));
         facturaText.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        facturaText.setText("Invoice");
+        facturaText.setText(Messages.get("factura.invoice"));
         facturaText.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         facturaContainer.add(facturaText, java.awt.BorderLayout.CENTER);
 

--- a/src/com/view/appointmentsView/FacturaData.java
+++ b/src/com/view/appointmentsView/FacturaData.java
@@ -51,12 +51,12 @@ public class FacturaData extends FacturaContext {
     }
     
     public void setStaticValues() {
-        textField3.setText("Enter balance");
-        textField2.setText("Enter total");
+        textField3.setText(Messages.get("factura.enterBalance"));
+        textField2.setText(Messages.get("factura.enterTotal"));
         
         for (int i = 0; i < 4; i++) {
             VALORES_MONTO.get(i).setText("$0.00");
-            ANOTACIONES_MONTO.get(i).setText("Enter notes");
+            ANOTACIONES_MONTO.get(i).setText(Messages.get("factura.enterNotes"));
         }
     }
     
@@ -237,7 +237,7 @@ public class FacturaData extends FacturaContext {
 
         textField2.setBackground(new java.awt.Color(255, 255, 255));
         textField2.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        textField2.setText("Enter total");
+        textField2.setText(Messages.get("factura.enterTotal"));
         textField2.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(0, 0, 0)));
         textField2.setOpaque(false);
         textField2.addKeyListener(new java.awt.event.KeyAdapter() {
@@ -263,7 +263,7 @@ public class FacturaData extends FacturaContext {
         jPanel4.add(container3, new org.netbeans.lib.awtextra.AbsoluteConstraints(40, 470, 420, 40));
 
         title2.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 14)); // NOI18N
-        title2.setText("Amounts");
+        title2.setText(Messages.get("factura.amounts"));
         jPanel4.add(title2, new org.netbeans.lib.awtextra.AbsoluteConstraints(40, 200, -1, -1));
 
         container1.setkEndColor(new java.awt.Color(204, 204, 204));
@@ -273,7 +273,7 @@ public class FacturaData extends FacturaContext {
 
         textField1.setBackground(new java.awt.Color(255, 255, 255));
         textField1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        textField1.setText("Enter notes");
+        textField1.setText(Messages.get("factura.enterNotes"));
         textField1.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(0, 0, 0)));
         textField1.setOpaque(false);
         textField1.addActionListener(new java.awt.event.ActionListener() {
@@ -299,7 +299,7 @@ public class FacturaData extends FacturaContext {
         jPanel4.add(container1, new org.netbeans.lib.awtextra.AbsoluteConstraints(140, 230, 320, 40));
 
         title3.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 14)); // NOI18N
-        title3.setText("Total");
+        title3.setText(Messages.get("factura.total"));
         jPanel4.add(title3, new org.netbeans.lib.awtextra.AbsoluteConstraints(40, 440, -1, -1));
 
         cross.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
@@ -312,7 +312,7 @@ public class FacturaData extends FacturaContext {
         jPanel4.add(cross, new org.netbeans.lib.awtextra.AbsoluteConstraints(460, 10, 30, 30));
 
         title4.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 14)); // NOI18N
-        title4.setText("Balance");
+        title4.setText(Messages.get("factura.balance"));
         jPanel4.add(title4, new org.netbeans.lib.awtextra.AbsoluteConstraints(40, 110, -1, -1));
 
         container2.setkEndColor(new java.awt.Color(204, 204, 204));
@@ -322,7 +322,7 @@ public class FacturaData extends FacturaContext {
 
         textField3.setBackground(new java.awt.Color(255, 255, 255));
         textField3.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        textField3.setText("Enter balance");
+        textField3.setText(Messages.get("factura.enterBalance"));
         textField3.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(0, 0, 0)));
         textField3.setOpaque(false);
         textField3.addMouseListener(new java.awt.event.MouseAdapter() {
@@ -443,7 +443,7 @@ public class FacturaData extends FacturaContext {
 
         textField6.setBackground(new java.awt.Color(255, 255, 255));
         textField6.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        textField6.setText("Enter notes");
+        textField6.setText(Messages.get("factura.enterNotes"));
         textField6.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(0, 0, 0)));
         textField6.setOpaque(false);
         textField6.addActionListener(new java.awt.event.ActionListener() {
@@ -517,7 +517,7 @@ public class FacturaData extends FacturaContext {
 
         textField8.setBackground(new java.awt.Color(255, 255, 255));
         textField8.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        textField8.setText("Enter notes");
+        textField8.setText(Messages.get("factura.enterNotes"));
         textField8.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(0, 0, 0)));
         textField8.setOpaque(false);
         textField8.addActionListener(new java.awt.event.ActionListener() {
@@ -591,7 +591,7 @@ public class FacturaData extends FacturaContext {
 
         textField10.setBackground(new java.awt.Color(255, 255, 255));
         textField10.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        textField10.setText("Enter notes");
+        textField10.setText(Messages.get("factura.enterNotes"));
         textField10.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(0, 0, 0)));
         textField10.setOpaque(false);
         textField10.addActionListener(new java.awt.event.ActionListener() {
@@ -617,11 +617,11 @@ public class FacturaData extends FacturaContext {
         jPanel4.add(container12, new org.netbeans.lib.awtextra.AbsoluteConstraints(140, 380, 320, 40));
 
         nombre.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
-        nombre.setText("Patient Name");
+        nombre.setText(Messages.get("factura.patientName"));
         jPanel4.add(nombre, new org.netbeans.lib.awtextra.AbsoluteConstraints(40, 60, 420, 30));
 
         text.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
-        text.setText("Consultation");
+        text.setText(Messages.get("factura.consultation"));
         jPanel4.add(text, new org.netbeans.lib.awtextra.AbsoluteConstraints(40, 40, -1, -1));
 
         jPanel2.add(jPanel4, java.awt.BorderLayout.CENTER);

--- a/src/com/view/components/Exit.java
+++ b/src/com/view/components/Exit.java
@@ -111,7 +111,7 @@ public class Exit extends javax.swing.JFrame {
 
         cancelar.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         cancelar.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        cancelar.setText("Cancelar");
+        cancelar.setText(Messages.get("form.cancelar"));
         cancelar.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         cancelar.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {

--- a/src/com/view/createAsistente/EstasSeguroAsistente.java
+++ b/src/com/view/createAsistente/EstasSeguroAsistente.java
@@ -96,7 +96,7 @@ public class EstasSeguroAsistente extends javax.swing.JFrame {
 
         cancelar.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         cancelar.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        cancelar.setText("Cancelar");
+        cancelar.setText(Messages.get("form.cancelar"));
         cancelar.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         cancelar.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
@@ -115,7 +115,7 @@ public class EstasSeguroAsistente extends javax.swing.JFrame {
 
         guardar.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         guardar.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        guardar.setText("Guardar");
+        guardar.setText(Messages.get("form.guardar"));
         guardar.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         guardar.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {

--- a/src/com/view/createPacient/EstasSeguro.java
+++ b/src/com/view/createPacient/EstasSeguro.java
@@ -96,7 +96,7 @@ public class EstasSeguro extends javax.swing.JFrame {
 
         cancelar.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         cancelar.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        cancelar.setText("Cancelar");
+        cancelar.setText(Messages.get("form.cancelar"));
         cancelar.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         cancelar.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
@@ -115,7 +115,7 @@ public class EstasSeguro extends javax.swing.JFrame {
 
         guardar.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         guardar.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        guardar.setText("Guardar");
+        guardar.setText(Messages.get("form.guardar"));
         guardar.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         guardar.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {

--- a/src/com/view/createPacient/NuevoPaciente.java
+++ b/src/com/view/createPacient/NuevoPaciente.java
@@ -362,7 +362,7 @@ public class NuevoPaciente extends Styles {
         title1.setBackground(new java.awt.Color(0, 0, 0));
         title1.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title1.setForeground(new java.awt.Color(0, 0, 0));
-        title1.setText("Nuevo paciente");
+        title1.setText(Messages.get("pacientes.nuevo"));
 
         containerButton.setkEndColor(new java.awt.Color(0, 0, 0));
         containerButton.setkFillBackground(false);
@@ -372,7 +372,7 @@ public class NuevoPaciente extends Styles {
         cancel.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         cancel.setForeground(new java.awt.Color(0, 0, 0));
         cancel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        cancel.setText("Cancelar");
+        cancel.setText(Messages.get("form.cancelar"));
         cancel.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         cancel.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
@@ -535,7 +535,7 @@ public class NuevoPaciente extends Styles {
         jLabel3.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         jLabel3.setForeground(new java.awt.Color(255, 255, 255));
         jLabel3.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        jLabel3.setText("Guardar");
+        jLabel3.setText(Messages.get("form.guardar"));
         jLabel3.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout saveButtonLayout = new javax.swing.GroupLayout(saveButton);

--- a/src/com/view/dashboard/DashboardView.java
+++ b/src/com/view/dashboard/DashboardView.java
@@ -3,6 +3,7 @@ package com.view.dashboard;
 import com.context.ApplicationContext;
 import com.context.ChoosedPalette;
 import com.utils.CustomScrollBar;
+import com.utils.Messages;
 import com.utils.Styles;
 import com.utils.Tools;
 import java.awt.BorderLayout;
@@ -323,11 +324,11 @@ public class DashboardView extends Styles {
 
         text1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text1.setForeground(new java.awt.Color(102, 102, 102));
-        text1.setText("Consultas pendientes registradas");
+        text1.setText(Messages.get("dashboard.consultasPendientesDesc"));
 
         title1.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title1.setForeground(new java.awt.Color(0, 0, 0));
-        title1.setText("Consultas pendientes");
+        title1.setText(Messages.get("dashboard.consultasPendientes"));
 
         jPanel90.setBackground(new java.awt.Color(69, 98, 255));
 
@@ -566,7 +567,7 @@ public class DashboardView extends Styles {
 
         text12.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text12.setForeground(new java.awt.Color(153, 153, 153));
-        text12.setText("Usuario");
+        text12.setText(Messages.get("dashboard.usuario"));
 
         javax.swing.GroupLayout jPanel21Layout = new javax.swing.GroupLayout(jPanel21);
         jPanel21.setLayout(jPanel21Layout);
@@ -592,7 +593,7 @@ public class DashboardView extends Styles {
         text13.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text13.setForeground(new java.awt.Color(153, 153, 153));
         text13.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        text13.setText("Actividad");
+        text13.setText(Messages.get("dashboard.actividad"));
 
         javax.swing.GroupLayout jPanel22Layout = new javax.swing.GroupLayout(jPanel22);
         jPanel22.setLayout(jPanel22Layout);
@@ -618,7 +619,7 @@ public class DashboardView extends Styles {
         text14.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text14.setForeground(new java.awt.Color(153, 153, 153));
         text14.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
-        text14.setText("Fecha");
+        text14.setText(Messages.get("date.fecha"));
 
         javax.swing.GroupLayout jPanel23Layout = new javax.swing.GroupLayout(jPanel23);
         jPanel23.setLayout(jPanel23Layout);
@@ -645,7 +646,7 @@ public class DashboardView extends Styles {
 
         text2.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text2.setForeground(new java.awt.Color(102, 102, 102));
-        text2.setText("Actividad realizada recientemente");
+        text2.setText(Messages.get("dashboard.actividadRealizadaDesc"));
 
         jPanel91.setBackground(new java.awt.Color(69, 98, 255));
 
@@ -662,7 +663,7 @@ public class DashboardView extends Styles {
 
         title2.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title2.setForeground(new java.awt.Color(0, 0, 0));
-        title2.setText("Actividad reciente");
+        title2.setText(Messages.get("dashboard.actividadReciente"));
 
         javax.swing.GroupLayout jPanel24Layout = new javax.swing.GroupLayout(jPanel24);
         jPanel24.setLayout(jPanel24Layout);

--- a/src/com/view/readPct/Agenda.java
+++ b/src/com/view/readPct/Agenda.java
@@ -741,7 +741,7 @@ public class Agenda extends Styles {
 
         text1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text1.setForeground(new java.awt.Color(153, 153, 153));
-        text1.setText("Patient consultations and schedule");
+        text1.setText(Messages.get("agenda.consultationsAndSchedule"));
 
         title1.setBackground(new java.awt.Color(0, 0, 0));
         title1.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
@@ -1035,7 +1035,7 @@ public class Agenda extends Styles {
         jLabel4.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         jLabel4.setForeground(new java.awt.Color(153, 153, 153));
         jLabel4.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        jLabel4.setText("Actions");
+        jLabel4.setText(Messages.get("agenda.actions"));
 
         javax.swing.GroupLayout jPanel103Layout = new javax.swing.GroupLayout(jPanel103);
         jPanel103.setLayout(jPanel103Layout);
@@ -1061,7 +1061,7 @@ public class Agenda extends Styles {
         jLabel5.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         jLabel5.setForeground(new java.awt.Color(153, 153, 153));
         jLabel5.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        jLabel5.setText("Consultation");
+        jLabel5.setText(Messages.get("agenda.consultation"));
 
         javax.swing.GroupLayout jPanel104Layout = new javax.swing.GroupLayout(jPanel104);
         jPanel104.setLayout(jPanel104Layout);
@@ -1317,7 +1317,7 @@ public class Agenda extends Styles {
 
         title2.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         title2.setForeground(new java.awt.Color(0, 0, 0));
-        title2.setText("Previous");
+        title2.setText(Messages.get("agenda.previous"));
 
         javax.swing.GroupLayout jPanel86Layout = new javax.swing.GroupLayout(jPanel86);
         jPanel86.setLayout(jPanel86Layout);
@@ -1353,7 +1353,7 @@ public class Agenda extends Styles {
         title3.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         title3.setForeground(new java.awt.Color(0, 0, 0));
         title3.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
-        title3.setText("Next");
+        title3.setText(Messages.get("agenda.next"));
 
         javax.swing.GroupLayout jPanel89Layout = new javax.swing.GroupLayout(jPanel89);
         jPanel89.setLayout(jPanel89Layout);
@@ -1381,7 +1381,7 @@ public class Agenda extends Styles {
         fecha.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 16)); // NOI18N
         fecha.setForeground(new java.awt.Color(0, 0, 0));
         fecha.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        fecha.setText("Month");
+        fecha.setText(Messages.get("agenda.month"));
 
         javax.swing.GroupLayout jPanel84Layout = new javax.swing.GroupLayout(jPanel84);
         jPanel84.setLayout(jPanel84Layout);

--- a/src/com/view/readPct/AgendaGeneralTarget.java
+++ b/src/com/view/readPct/AgendaGeneralTarget.java
@@ -233,7 +233,7 @@ public class AgendaGeneralTarget extends Styles {
         button.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         button.setForeground(new java.awt.Color(255, 255, 255));
         button.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        button.setText("Invoice");
+        button.setText(Messages.get("factura.invoice"));
         button.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout container3Layout = new javax.swing.GroupLayout(container3);

--- a/src/com/view/readPct/AgendaTarget.java
+++ b/src/com/view/readPct/AgendaTarget.java
@@ -32,7 +32,7 @@ public class AgendaTarget extends Styles {
         
         if (consulta.isConsultaRealizada()) {
             paintOneContainer(facturaContainer, ChoosedPalette.getSecondaryLightColor());
-            factura.setText("View Invoice");
+            factura.setText(Messages.get("factura.ver"));
         }
     }
     
@@ -51,7 +51,7 @@ public class AgendaTarget extends Styles {
     public void initStyles() {
         editIcon.setSize(34, 58);
         Tools.setImageLabel(editIcon, "src/com/assets/editar.png", 10, 32, ChoosedPalette.getMidColor());
-        factura.setText("Invoice");
+        factura.setText(Messages.get("factura.invoice"));
         facturaContainer.setkStartColor(ChoosedPalette.getMidColor());
         facturaContainer.setkEndColor(ChoosedPalette.getMidColor());
         paintOneContainer(facturaContainer, ChoosedPalette.getMidColor());
@@ -284,7 +284,7 @@ public class AgendaTarget extends Styles {
         factura.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         factura.setForeground(new java.awt.Color(255, 255, 255));
         factura.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        factura.setText("Invoice");
+        factura.setText(Messages.get("factura.invoice"));
         factura.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         facturaContainer.add(factura, java.awt.BorderLayout.CENTER);
 

--- a/src/com/view/readPct/ControlMensual.java
+++ b/src/com/view/readPct/ControlMensual.java
@@ -299,11 +299,11 @@ public class ControlMensual extends Styles {
 
         text2.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text2.setForeground(new java.awt.Color(102, 102, 102));
-        text2.setText("Monthly Control");
+        text2.setText(Messages.get("control.mensual"));
 
         text1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text1.setForeground(new java.awt.Color(102, 102, 102));
-        text1.setText("Orthodontics Record  /");
+        text1.setText(Messages.get("control.record") + "  /");
         text1.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
         text1.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
@@ -454,7 +454,7 @@ public class ControlMensual extends Styles {
 
         jLabel1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         jLabel1.setForeground(new java.awt.Color(255, 255, 255));
-        jLabel1.setText("Back");
+        jLabel1.setText(Messages.get("control.back"));
         jLabel1.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         back.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
@@ -681,7 +681,7 @@ public class ControlMensual extends Styles {
         text5.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text5.setForeground(new java.awt.Color(153, 153, 153));
         text5.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        text5.setText("Actions");
+        text5.setText(Messages.get("control.actions"));
         text5.setVerticalAlignment(javax.swing.SwingConstants.BOTTOM);
 
         javax.swing.GroupLayout jPanel30Layout = new javax.swing.GroupLayout(jPanel30);
@@ -802,7 +802,7 @@ public class ControlMensual extends Styles {
 
         addText.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         addText.setForeground(new java.awt.Color(69, 98, 255));
-        addText.setText("New Monthly Control");
+        addText.setText(Messages.get("control.nuevo"));
         addText.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         addIcon.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);

--- a/src/com/view/readPct/GeneralDatos.java
+++ b/src/com/view/readPct/GeneralDatos.java
@@ -4,6 +4,7 @@ import com.context.ApplicationContext;
 import com.context.ChoosedPalette;
 import com.context.StateColors;
 import com.utils.CustomScrollBar;
+import com.utils.Messages;
 import com.utils.Styles;
 import com.utils.Tools;
 import javax.swing.border.MatteBorder;
@@ -71,9 +72,9 @@ public class GeneralDatos extends Styles {
             ApplicationContext.tratamientosTargets.forEach(tratamiento -> tratamientos.add(tratamiento));
 
             if (ApplicationContext.selectedPacient.getEstadoDeActividad().equals("activo")) {
-                status.setText("Activo");
+                status.setText(Messages.get("status.activo"));
             } else {
-                status.setText("Inactivo");
+                status.setText(Messages.get("status.inactivo"));
             }
             
             colorComponent(ApplicationContext.selectedAppereance);
@@ -333,11 +334,11 @@ public class GeneralDatos extends Styles {
         title2.setBackground(new java.awt.Color(0, 0, 0));
         title2.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title2.setForeground(new java.awt.Color(0, 0, 0));
-        title2.setText("Estado");
+        title2.setText(Messages.get("pacientes.estado"));
 
         text2.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text2.setForeground(new java.awt.Color(153, 153, 153));
-        text2.setText("Estado del paciente");
+        text2.setText(Messages.get("pacientes.estadoDesc"));
 
         statusContainer.setBackground(new java.awt.Color(255, 255, 255));
         statusContainer.setkEndColor(new java.awt.Color(204, 255, 204));
@@ -349,7 +350,7 @@ public class GeneralDatos extends Styles {
         status.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 14)); // NOI18N
         status.setForeground(new java.awt.Color(0, 255, 0));
         status.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        status.setText("Activo");
+        status.setText(Messages.get("status.activo"));
 
         javax.swing.GroupLayout statusContainerLayout = new javax.swing.GroupLayout(statusContainer);
         statusContainer.setLayout(statusContainerLayout);
@@ -502,11 +503,11 @@ public class GeneralDatos extends Styles {
         title1.setBackground(new java.awt.Color(0, 0, 0));
         title1.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title1.setForeground(new java.awt.Color(0, 0, 0));
-        title1.setText("Tratamientos del paciente");
+        title1.setText(Messages.get("pacientes.tratamientos"));
 
         text1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text1.setForeground(new java.awt.Color(153, 153, 153));
-        text1.setText("Los tratamientos que recibe el paciente");
+        text1.setText(Messages.get("pacientes.tratamientosDesc"));
 
         jPanel19.setBackground(new java.awt.Color(255, 255, 255));
         jPanel19.setOpaque(false);
@@ -674,11 +675,11 @@ public class GeneralDatos extends Styles {
         title3.setBackground(new java.awt.Color(0, 0, 0));
         title3.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title3.setForeground(new java.awt.Color(0, 0, 0));
-        title3.setText("Agenda del paciente");
+        title3.setText(Messages.get("pacientes.agendaGeneral"));
 
         text4.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text4.setForeground(new java.awt.Color(153, 153, 153));
-        text4.setText("Agenda general del paciente");
+        text4.setText(Messages.get("pacientes.agendaGeneralDesc"));
 
         javax.swing.GroupLayout jPanel37Layout = new javax.swing.GroupLayout(jPanel37);
         jPanel37.setLayout(jPanel37Layout);
@@ -742,7 +743,7 @@ public class GeneralDatos extends Styles {
         agenda.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         agenda.setForeground(new java.awt.Color(0, 0, 0));
         agenda.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        agenda.setText("Ir a agenda");
+        agenda.setText(Messages.get("pacientes.irAgenda"));
         agenda.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout buttonAgendaLayout = new javax.swing.GroupLayout(buttonAgenda);
@@ -789,7 +790,7 @@ public class GeneralDatos extends Styles {
 
         text6.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text6.setForeground(new java.awt.Color(153, 153, 153));
-        text6.setText("Fecha");
+        text6.setText(Messages.get("date.fecha"));
 
         javax.swing.GroupLayout jPanel42Layout = new javax.swing.GroupLayout(jPanel42);
         jPanel42.setLayout(jPanel42Layout);
@@ -815,7 +816,7 @@ public class GeneralDatos extends Styles {
 
         text5.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text5.setForeground(new java.awt.Color(153, 153, 153));
-        text5.setText("Hora");
+        text5.setText(Messages.get("date.hora"));
 
         javax.swing.GroupLayout jPanel43Layout = new javax.swing.GroupLayout(jPanel43);
         jPanel43.setLayout(jPanel43Layout);
@@ -857,7 +858,7 @@ public class GeneralDatos extends Styles {
 
         text7.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text7.setForeground(new java.awt.Color(153, 153, 153));
-        text7.setText("Consulta");
+        text7.setText(Messages.get("agenda.consultation"));
 
         javax.swing.GroupLayout jPanel44Layout = new javax.swing.GroupLayout(jPanel44);
         jPanel44.setLayout(jPanel44Layout);

--- a/src/com/view/readPct/ModificarControl.java
+++ b/src/com/view/readPct/ModificarControl.java
@@ -4,6 +4,7 @@ import com.context.ApplicationContext;
 import com.context.ChoosedPalette;
 import com.helper.ControlMensualHelper;
 import com.model.ControlMensualModel;
+import com.utils.Messages;
 import com.utils.Styles;
 import com.utils.Tools;
 
@@ -240,7 +241,7 @@ public class ModificarControl extends Styles {
         jLabel3.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         jLabel3.setForeground(new java.awt.Color(255, 255, 255));
         jLabel3.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        jLabel3.setText("Guardar");
+        jLabel3.setText(Messages.get("form.guardar"));
         jLabel3.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout saveButtonLayout = new javax.swing.GroupLayout(saveButton);
@@ -273,7 +274,7 @@ public class ModificarControl extends Styles {
         cancel.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         cancel.setForeground(new java.awt.Color(255, 255, 255));
         cancel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        cancel.setText("Cancelar");
+        cancel.setText(Messages.get("form.cancelar"));
         cancel.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout cancelButtonLayout = new javax.swing.GroupLayout(cancelButton);

--- a/src/com/view/readPct/NuevoControl.java
+++ b/src/com/view/readPct/NuevoControl.java
@@ -3,6 +3,7 @@ package com.view.readPct;
 import com.context.ApplicationContext;
 import com.context.ChoosedPalette;
 import com.helper.ControlMensualHelper;
+import com.utils.Messages;
 import com.utils.Styles;
 import com.utils.Tools;
 
@@ -239,7 +240,7 @@ public class NuevoControl extends Styles {
         jLabel3.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         jLabel3.setForeground(new java.awt.Color(255, 255, 255));
         jLabel3.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        jLabel3.setText("Guardar");
+        jLabel3.setText(Messages.get("form.guardar"));
         jLabel3.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout saveButtonLayout = new javax.swing.GroupLayout(saveButton);
@@ -272,7 +273,7 @@ public class NuevoControl extends Styles {
         cancel.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         cancel.setForeground(new java.awt.Color(255, 255, 255));
         cancel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
-        cancel.setText("Cancelar");
+        cancel.setText(Messages.get("form.cancelar"));
         cancel.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
 
         javax.swing.GroupLayout cancelButtonLayout = new javax.swing.GroupLayout(cancelButton);

--- a/src/com/view/readPct/NuevoControlFields.java
+++ b/src/com/view/readPct/NuevoControlFields.java
@@ -2,6 +2,7 @@ package com.view.readPct;
 
 import com.context.ChoosedPalette;
 import com.model.ControlMensualModel;
+import com.utils.Messages;
 import com.utils.Styles;
 import com.utils.Tools;
 import com.view.createPacient.NewContext;
@@ -188,12 +189,12 @@ public class NuevoControlFields extends Styles {
 
         text1.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 12)); // NOI18N
         text1.setForeground(new java.awt.Color(153, 153, 153));
-        text1.setText("Agrega un nuevo control mensual para el paciente");
+        text1.setText(Messages.get("control.descripcion"));
 
         title1.setBackground(new java.awt.Color(0, 0, 0));
         title1.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 18)); // NOI18N
         title1.setForeground(new java.awt.Color(0, 0, 0));
-        title1.setText("Nuevo control mensual");
+        title1.setText(Messages.get("control.nuevoTitulo"));
 
         kGradientPanel3.setkBorderRadius(100);
         kGradientPanel3.setkEndColor(new java.awt.Color(69, 98, 255));
@@ -301,7 +302,7 @@ public class NuevoControlFields extends Styles {
         container1.add(jPanel45, java.awt.BorderLayout.LINE_START);
 
         textField1.setBackground(new java.awt.Color(255, 255, 255));
-        textField1.setText("Ingresar MD");
+        textField1.setText(Messages.get("control.ingresarMD"));
         textField1.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(204, 204, 204)));
         textField1.setOpaque(false);
         textField1.addKeyListener(new java.awt.event.KeyAdapter() {
@@ -396,7 +397,7 @@ public class NuevoControlFields extends Styles {
         container4.add(jPanel51, java.awt.BorderLayout.LINE_START);
 
         textField4.setBackground(new java.awt.Color(255, 255, 255));
-        textField4.setText("Ingresar MX");
+        textField4.setText(Messages.get("control.ingresarMX"));
         textField4.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(204, 204, 204)));
         textField4.setOpaque(false);
         textField4.addKeyListener(new java.awt.event.KeyAdapter() {
@@ -501,7 +502,7 @@ public class NuevoControlFields extends Styles {
         container5.add(jPanel53, java.awt.BorderLayout.LINE_START);
 
         textField5.setBackground(new java.awt.Color(255, 255, 255));
-        textField5.setText("Ingresar cadenas");
+        textField5.setText(Messages.get("control.ingresarCadenas"));
         textField5.setToolTipText("");
         textField5.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(204, 204, 204)));
         textField5.setOpaque(false);
@@ -514,7 +515,7 @@ public class NuevoControlFields extends Styles {
 
         title4.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         title4.setForeground(new java.awt.Color(0, 0, 0));
-        title4.setText("Cadenas");
+        title4.setText(Messages.get("control.cadenas"));
 
         advertenciaCadenas.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 10)); // NOI18N
         advertenciaCadenas.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
@@ -604,7 +605,7 @@ public class NuevoControlFields extends Styles {
         container6.add(jPanel55, java.awt.BorderLayout.LINE_START);
 
         textField6.setBackground(new java.awt.Color(255, 255, 255));
-        textField6.setText("Ingresar hules");
+        textField6.setText(Messages.get("control.ingresarHules"));
         textField6.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(204, 204, 204)));
         textField6.setOpaque(false);
         textField6.addKeyListener(new java.awt.event.KeyAdapter() {
@@ -616,7 +617,7 @@ public class NuevoControlFields extends Styles {
 
         title5.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         title5.setForeground(new java.awt.Color(0, 0, 0));
-        title5.setText("Hules");
+        title5.setText(Messages.get("control.hules"));
 
         advertenciaNombre5.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 10)); // NOI18N
         advertenciaNombre5.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
@@ -702,7 +703,7 @@ public class NuevoControlFields extends Styles {
         container7.add(jPanel57, java.awt.BorderLayout.LINE_START);
 
         textField7.setBackground(new java.awt.Color(255, 255, 255));
-        textField7.setText("Ingresar observaciones");
+        textField7.setText(Messages.get("control.ingresarObservaciones"));
         textField7.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 1, 0, new java.awt.Color(204, 204, 204)));
         textField7.setOpaque(false);
         textField7.addKeyListener(new java.awt.event.KeyAdapter() {
@@ -714,7 +715,7 @@ public class NuevoControlFields extends Styles {
 
         title6.setFont(new java.awt.Font("Microsoft YaHei UI", 1, 12)); // NOI18N
         title6.setForeground(new java.awt.Color(0, 0, 0));
-        title6.setText("Observaciones");
+        title6.setText(Messages.get("medical.observaciones"));
 
         advertenciaNombre6.setFont(new java.awt.Font("Microsoft YaHei UI", 0, 10)); // NOI18N
         advertenciaNombre6.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);

--- a/src/resources/messages.properties
+++ b/src/resources/messages.properties
@@ -50,6 +50,11 @@ dashboard.proximasCitas=Upcoming Appointments
 dashboard.actividad=Activity
 dashboard.estadisticas=Statistics
 dashboard.noResultados=No results found
+dashboard.consultasPendientes=Pending Consultations
+dashboard.consultasPendientesDesc=Registered pending consultations
+dashboard.usuario=User
+dashboard.actividadReciente=Recent Activity
+dashboard.actividadRealizadaDesc=Recently performed activity
 
 # Patients
 pacientes.nuevo=New Patient
@@ -66,6 +71,13 @@ pacientes.contacto=Contact
 pacientes.expediente=Medical Record
 pacientes.historial=History
 pacientes.tratamiento=Treatment
+pacientes.estado=Patient Status
+pacientes.estadoDesc=Patient status
+pacientes.tratamientos=Patient Treatments
+pacientes.tratamientosDesc=Treatments that the patient receives
+pacientes.agendaGeneral=Patient Schedule
+pacientes.agendaGeneralDesc=General patient schedule
+pacientes.irAgenda=Go to schedule
 
 # Patient Information
 paciente.informacionGeneral=General Information
@@ -130,6 +142,25 @@ agenda.tipo=Type
 agenda.estado=Status
 agenda.observaciones=Observations
 agenda.recordatorio=Reminder
+agenda.consultationsAndSchedule=Patient consultations and schedule
+agenda.actions=Actions
+agenda.consultation=Consultation
+agenda.previous=Previous
+agenda.next=Next
+agenda.month=Month
+
+# Invoice
+factura.ver=View Invoice
+factura.nueva=New Invoice
+factura.invoice=Invoice
+factura.amounts=Amounts
+factura.total=Total
+factura.balance=Balance
+factura.enterBalance=Enter balance
+factura.enterTotal=Enter total
+factura.enterNotes=Enter notes
+factura.patientName=Patient Name
+factura.consultation=Consultation
 
 # X-rays
 radiografias.nueva=New X-ray
@@ -198,6 +229,20 @@ date.hoy=Today
 date.ayer=Yesterday
 date.manana=Tomorrow
 
+# Months
+month.january=January
+month.february=February
+month.march=March
+month.april=April
+month.may=May
+month.june=June
+month.july=July
+month.august=August
+month.september=September
+month.october=October
+month.november=November
+month.december=December
+
 # Application States
 app.conectando=Connecting
 app.cargando=Loading application
@@ -263,6 +308,22 @@ ortho.maloclusion=Malocclusion
 ortho.expansion=Expansion
 ortho.mantenedor=Maintainer
 
+# Control
+control.mensual=Monthly Control
+control.record=Orthodontics Record
+control.nuevo=New Monthly Control
+control.back=Back
+control.actions=Actions
+control.descripcion=Add a new monthly control for the patient
+control.nuevoTitulo=New monthly control
+control.ingresarMD=Enter MD
+control.ingresarMX=Enter MX
+control.ingresarCadenas=Enter chains
+control.cadenas=Chains
+control.ingresarHules=Enter rubbers
+control.hules=Rubbers
+control.ingresarObservaciones=Enter observations
+
 # Status Messages
 status.activo=Active
 status.inactivo=Inactive
@@ -272,3 +333,82 @@ status.cancelado=Cancelled
 status.programado=Scheduled
 status.enProceso=In Process
 status.finalizado=Finished
+
+# Plural Forms
+count.patient.singular={0} patient
+count.patient.plural={0} patients
+count.consultation.singular={0} consultation
+count.consultation.plural={0} consultations
+count.appointment.singular={0} appointment
+count.appointment.plural={0} appointments
+count.assistant.singular={0} assistant
+count.assistant.plural={0} assistants
+count.xray.singular={0} X-ray
+count.xray.plural={0} X-rays
+count.record.singular={0} record
+count.record.plural={0} records
+count.result.singular={0} result found
+count.result.plural={0} results found
+count.item.singular={0} item
+count.item.plural={0} items
+count.file.singular={0} file
+count.file.plural={0} files
+
+# Dynamic Count Messages
+msg.patientsFound.singular=Found {0} patient
+msg.patientsFound.plural=Found {0} patients
+msg.consultationsToday.singular=You have {0} consultation today
+msg.consultationsToday.plural=You have {0} consultations today
+msg.appointmentsScheduled.singular={0} appointment scheduled
+msg.appointmentsScheduled.plural={0} appointments scheduled
+msg.recordsUpdated.singular={0} record updated
+msg.recordsUpdated.plural={0} records updated
+msg.itemsSelected.singular={0} item selected
+msg.itemsSelected.plural={0} items selected
+
+# Days of the Week
+day.sunday=Sunday
+day.monday=Monday
+day.tuesday=Tuesday
+day.wednesday=Wednesday
+day.thursday=Thursday
+day.friday=Friday
+day.saturday=Saturday
+
+# Months of the Year
+month.january=January
+month.february=February
+month.march=March
+month.april=April
+month.may=May
+month.june=June
+month.july=July
+month.august=August
+month.september=September
+month.october=October
+month.november=November
+month.december=December
+
+# Short Month Names
+month.short.jan=Jan
+month.short.feb=Feb
+month.short.mar=Mar
+month.short.apr=Apr
+month.short.may=May
+month.short.jun=Jun
+month.short.jul=Jul
+month.short.aug=Aug
+month.short.sep=Sep
+month.short.oct=Oct
+month.short.nov=Nov
+month.short.dec=Dec
+
+# Date Format Examples
+date.format.example=MM/dd/yyyy
+date.format.time.example=HH:mm
+date.format.datetime.example=MM/dd/yyyy HH:mm
+date.placeholder.day=DD
+date.placeholder.month=MM
+date.placeholder.year=YYYY
+date.placeholder.hour=HH
+date.placeholder.minute=MM


### PR DESCRIPTION
## Summary
- Introduces a new `DateTimeFormatter` utility class for consistent English locale date/time formatting
- Sets default language strings to English in UI components and messages
- Adds pluralization support in `Messages` utility for English
- Updates UI text in multiple views to use localized English messages from resource bundle

## Changes

### Utilities
- Added `DateTimeFormatter.java` with methods for formatting dates, times, full dates, month-year, short dates, and relative times in English
- Enhanced `Messages.java` to support plural forms and count-based message retrieval

### Localization
- Added English language keys and plural forms to `messages.properties` for months, days, UI labels, and dynamic counts

### UI Components
- Updated text labels in appointment views, dashboard, patient views, control views, and invoice views to use English localized messages via `Messages.get()` calls
- Replaced hardcoded Spanish month names and UI strings with English keys

## Test plan
- Verify date/time formatting methods produce correct English formatted strings
- Confirm UI labels display English text from resource bundle
- Check pluralization methods return correct singular/plural forms
- Test relative time descriptions (Today, Yesterday, Tomorrow) show correctly in English
- Validate no UI regressions or missing translations after changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/62b17347-a4e3-44c7-a179-a1e0ea56efd6